### PR TITLE
Add eager quantifiers

### DIFF
--- a/rhemyn/README.md
+++ b/rhemyn/README.md
@@ -24,13 +24,16 @@ Made for use with Porffor but could possibly be adapted, implementation/library 
   - 🟢 digit, not digit (eg `\d\D`)
   - 🟢 word, not word (eg `\w\W`)
   - 🟢 whitespace, not whitespace (eg `\s\S`)
-- 🟠 quantifiers
-  - 🟠 star (eg `a*`)
-  - 🟠 plus (eg `a+`)
-  - 🟠 optional (eg `a?`)
+- 🟡 quantifiers
+  - 🟡 star (eg `a*`)
+  - 🟡 plus (eg `a+`)
+  - 🟡 optional (eg `a?`)
   - 🟠 lazy modifier (eg `a*?`)
   - 🔴 n repetitions (eg `a{4}`)
   - 🔴 n-m repetitions (eg `a{2,4}`)
+- 🟠 groups
+  - 🟠 capturing groups (`(a)`)
+  - 🔴 non-capturing groups (`(?:a)`)
 - 🔴 assertions
   - 🔴 beginning (eg `^a`)
   - 🔴 end (eg `a$`)

--- a/rhemyn/compile.js
+++ b/rhemyn/compile.js
@@ -195,8 +195,9 @@ const wrapQuantifier = (node, method, get, stringSize) => {
 }
 
 const generateChar = (node, negated, get, stringSize) => {
+  const hasQuantifier = !!node.quantifier
   const out = [
-    ...(get ? getNextChar(stringSize, true) : []),
+    ...(get ? getNextChar(stringSize, hasQuantifier) : []),
     ...number(node.char.charCodeAt(0), Valtype.i32),
     negated ? [ Opcodes.i32_eq ] : [ Opcodes.i32_ne ],
   ]

--- a/test/regex_lit1.js
+++ b/test/regex_lit1.js
@@ -1,0 +1,3 @@
+// "10"
+print(/a/.test("a"))
+print(/a/.test(""))

--- a/test/regex_lit1.js
+++ b/test/regex_lit1.js
@@ -1,3 +1,4 @@
 // "10"
 print(/a/.test("a"))
-print(/a/.test(""))
+print(/a/.test("b"))
+// print(/a/.test(""))

--- a/test/regex_lit2.js
+++ b/test/regex_lit2.js
@@ -1,0 +1,5 @@
+// "110"
+print(/aa/.test("aa"))
+print(/aa/.test("aaa"))
+print(/aa/.test("ab"))
+// print(/aa/.test(""))

--- a/test/regex_quantifier.js
+++ b/test/regex_quantifier.js
@@ -1,0 +1,23 @@
+// "1110111111"
+console.log("\n?")
+print(/a?/.test("a"))
+print(/a?/.test(""))
+print(/a?/.test("b"))
+
+console.log("\n+")
+print(/a+/.test("b"))
+print(/a+/.test("a"))
+print(/a+/.test("aaaaaaa"))
+// print(/a+/.test(""))
+
+console.log("\n*")
+print(/a*/.test("a"))
+print(/a*/.test("aaaaaaa"))
+print(/a*/.test(""))
+
+console.log("\nset")
+print(/[ab]+/.test("abababa"))
+
+console.log("\nset+")
+print(/[ab]+/.test("abababa"))
+print(/[a-c]+/.test("abcabc"))

--- a/test/regex_quantifier2.js
+++ b/test/regex_quantifier2.js
@@ -1,0 +1,5 @@
+// "0011"
+print(/a+b+/.test("a"))
+print(/a+b+/.test("b"))
+print(/a+b+/.test("ab"))
+print(/a+b+/.test("aaaabbbbb"))

--- a/test/regex_set.js
+++ b/test/regex_set.js
@@ -1,0 +1,6 @@
+// "1110"
+print(/[a]/.test("a"))
+
+print(/[ab]/.test("a"))
+print(/[ab]/.test("b"))
+print(/[ab]/.test("c"))

--- a/test/regex_set2.js
+++ b/test/regex_set2.js
@@ -1,0 +1,5 @@
+// "1110"
+print(/[a-c]/.test("a"))
+print(/[a-c]/.test("b"))
+print(/[a-c]/.test("c"))
+print(/[a-c]/.test("d"))


### PR DESCRIPTION
Exactly as the title says, no support for lazy quantifiers as lookbehind increases complexity significantly, and could cause issues with a future group implementation. I decided to separate these as whenever groups are implemented lazy quantifiers likely will have to be changed regardless. 
 