### PR TITLE
Add some debug flags to internal utilities

### DIFF
--- a/compiler/wrap.js
+++ b/compiler/wrap.js
@@ -222,7 +222,7 @@ export default (source, flags = [ 'module' ], customImports = {}, print = str =>
     }
 
     if (i === wasm.length) {
-      printDecomp(-1, func, funcs, globals, exceptions)
+      printDecomp(-1, func, funcs, globals, exceptions);
       return false;
     }
 
@@ -236,13 +236,13 @@ export default (source, flags = [ 'module' ], customImports = {}, print = str =>
     }
 
     if (cumLen !== offset)  {
-      printDecomp(-1, func, funcs, globals, exceptions)
+      printDecomp(-1, func, funcs, globals, exceptions);
       return false;
     }
 
     i -= 1;
 
-    printDecomp(i, func, funcs, globals, exceptions)
+    printDecomp(i, func, funcs, globals, exceptions);
 
     return true;
   };

--- a/compiler/wrap.js
+++ b/compiler/wrap.js
@@ -151,15 +151,12 @@ export default (source, flags = [ 'module' ], customImports = {}, print = str =>
     console.log(`\x1B[35m\x1B[1mporffor backtrace\u001b[0m`);
     console.log('\x1B[4m' + func.name + '\x1B[0m');
     
-    const surrounding = Prefs.debugSurrounding ?? 5;
+    const surrounding = Prefs.backtraceSurrounding ?? 5;
     let min = middleIndex - surrounding;
     let max = middleIndex + surrounding + 1;
-    if (Prefs.debugVerbose) {
+    if (Prefs.backtraceEntireFunc || middleIndex == -1) {
       min = 0;
       max = func.wasm.length;
-    } else if (middleIndex == -1) {
-      min = 0;
-      max = surrounding * 2;
     }
     
     const decomp = decompile(func.wasm.slice(min, max), '', 0, func.locals, func.params, func.returns, funcs, globals, exceptions).slice(0, -1).split('\n');

--- a/test262/index.js
+++ b/test262/index.js
@@ -84,6 +84,7 @@ if (isMainThread) {
   const logErrors = process.argv.includes('--log-errors');
   const debugAsserts = process.argv.includes('--debug-asserts');
   const subdirs = process.argv.includes('--subdirs');
+  const dontWriteResults = process.argv.includes('--dont-write-results');
 
   const start = performance.now();
 
@@ -285,7 +286,7 @@ if (isMainThread) {
     if (lastResults.passes) console.log(`\u001b[4mnew passes\u001b[0m\n${passFiles.filter(x => !lastResults.passes.includes(x)).join('\n')}\n\n`);
     if (lastResults.passes) console.log(`\u001b[4mnew fails\u001b[0m\n${lastResults.passes.filter(x => !passFiles.includes(x)).join('\n')}`);
 
-    fs.writeFileSync('test262/results.json', JSON.stringify({ passes: passFiles, compileErrors: compileErrorFiles, wasmErrors: wasmErrorFiles, total }));
+    if (!dontWriteResults) fs.writeFileSync('test262/results.json', JSON.stringify({ passes: passFiles, compileErrors: compileErrorFiles, wasmErrors: wasmErrorFiles, total }));
   }
 
   console.log(`\u001b[90mtook ${((performance.now() - start) / 1000).toFixed(1)}s to run (${((performance.now() - veryStart) / 1000).toFixed(1)}s total)\u001b[0m`);

--- a/test262/index.js
+++ b/test262/index.js
@@ -85,6 +85,7 @@ if (isMainThread) {
   const debugAsserts = process.argv.includes('--debug-asserts');
   const subdirs = process.argv.includes('--subdirs');
   const dontWriteResults = process.argv.includes('--dont-write-results');
+  const plainResults = process.argv.includes('--plain-results');
 
   const start = performance.now();
 
@@ -193,12 +194,13 @@ if (isMainThread) {
     let out = '';
     for (let i = 0; i < arr.length; i++) {
       let icon = [ '🧪', '🤠', '❌', '💀', '🏗️', '💥', '⏰', '📝' ][i];
+      let iconDesc = [ 'total', 'pass', 'fail', 'runtime error', 'wasm compile error', 'compile error', 'timeout', 'todo' ][i];
       // let color = resultOnly ? '' : ['', '\u001b[42m', '\u001b[43m', '\u001b[101m', '\u001b[41m', '\u001b[41m', '\u001b[101m', todoTime === 'runtime' ? '\u001b[101m' : '\u001b[41m'][i];
       // let color = resultOnly ? '' : ('\u001b[1m' + ['', '\u001b[32m', '\u001b[33m', '\u001b[91m', '\u001b[31m', '\u001b[31m', '\u001b[91m', todoTime === 'runtime' ? '\u001b[91m' : '\u001b[31m'][i]);
 
       let change = arr[i] - lastCommitResults[i + 1];
       // let str = `${color}${icon} ${arr[i]}${resultOnly ? '' : '\u001b[0m'}${overall && change !== 0 ? ` (${change > 0 ? '+' : ''}${change})` : ''}`;
-      let str = `${resultOnly ? '' : '\u001b[1m'}${icon} ${arr[i]}${resultOnly ? '' : '\u001b[0m'}${overall && change !== 0 ? ` (${change > 0 ? '+' : ''}${change})` : ''}`;
+      let str = `${resultOnly ? '' : '\u001b[1m'}${plainResults ? iconDesc : icon} ${arr[i]}${resultOnly ? '' : '\u001b[0m'}${overall && change !== 0 ? ` (${change > 0 ? '+' : ''}${change})` : ''}`;
 
       if (i !== arr.length - 1) str += resultOnly ? ' | ' : '\u001b[90m | \u001b[0m';
       out += str;


### PR DESCRIPTION
Summary:
- adds the `--dont-write-results` flag to the test262 runner, which doesn't write the final results.json and just logs the differences
- adds the `--plain-results `flag to the test262 runner, which converts all the emojis into plain english 
- adds the `--debug-verbose` flag to `porf` which whenever a wasm error is thrown and the decompilation of the function is logged, it doesn't only get the surrounding lines, but the entire function instead
- adds the `--debug-surrounding` flag as an alternative to the above, instead of logging the entire function it logs the n lines around it 