### PR TITLE
WebAssembly backend: Emit function/variable names

### DIFF
--- a/compiler/builtins.js
+++ b/compiler/builtins.js
@@ -52,6 +52,12 @@ export const importedFuncs = [
     import: 'q',
     params: 2,
     returns: 1
+  },
+  {
+    name: 'debugger',
+    import: 'b',
+    params: 0,
+    returns: 0,
   }
 ];
 

--- a/compiler/codegen.js
+++ b/compiler/codegen.js
@@ -137,7 +137,7 @@ const generate = (scope, decl, global = false, name = undefined, valueUnused = f
 
     case 'DebuggerStatement':
       // todo: hook into terminal debugger
-      return [];
+      return [[ Opcodes.call, importedFuncs.debugger ]];
 
     case 'ArrayExpression':
       return generateArray(scope, decl, global, name);

--- a/compiler/wrap.js
+++ b/compiler/wrap.js
@@ -284,6 +284,9 @@ export default (source, flags = [ 'module' ], customImports = {}, print = str =>
             return -1;
           }
         },
+        b: () => {
+          debugger;
+        },
         ...customImports
       }
     });


### PR DESCRIPTION
I can split the `debugger` change into its own PR if you'd prefer, but it was useful for debugging this change. Note that I haven't (yet) implemented breakpoints in the C backend because would require a little bit of architecture-specific code.

<details>
<summary>Example `wasm2wat` diff</summary>

```diff
-(module
+(module $js
   (type (;0;) (func (param f64)))
   (type (;1;) (func))
   (type (;2;) (func (param f64 i32) (result f64 i32)))
@@ -6,22 +6,22 @@
   (import "" "c" (func (;0;) (type 0)))
   (import "" "b" (func (;1;) (type 1)))
   (import "" "p" (func (;2;) (type 0)))
-  (func (;3;) (type 1)
-    (local i32)
+  (func $main (type 1)
+    (local $#last_type i32)
     f64.const 0x1.8p+3 (;=12;)
     i32.const 0
-    call 4
-    local.tee 0
-    call 5
+    call $factorial
+    local.tee $#last_type
+    call $__Porffor_print
     f64.const 0x1.4p+3 (;=10;)
     call 0
     call 1)
-  (func (;4;) (type 2) (param f64 i32) (result f64 i32)
-    (local i32)
-    local.get 0
+  (func $factorial (type 2) (param $n f64) (param $n#type i32) (result f64 i32)
+    (local $#last_type i32)
+    local.get $n
     f64.const 0x0p+0 (;=0;)
     f64.eq
-    local.get 1
+    local.get $n#type
     i32.const 128
     i32.or
     i32.const 0
@@ -32,39 +32,39 @@
     if (result f64)  ;; label = @1
       f64.const 0x1p+0 (;=1;)
       i32.const 0
-      local.set 2
+      local.set $#last_type
     else
-      local.get 0
-      local.get 0
+      local.get $n
+      local.get $n
       f64.const 0x1p+0 (;=1;)
       f64.sub
       i32.const 0
-      call 4
-      local.set 2
+      call $factorial
+      local.set $#last_type
       f64.mul
       i32.const 0
-      local.set 2
+      local.set $#last_type
     end
-    local.get 2
+    local.get $#last_type
     return)
-  (func (;5;) (type 3) (param f64 i32)
-    (local i32 i32 i32)
-    local.get 1
-    local.set 4
+  (func $__Porffor_print (type 3) (param $x f64) (param $y i32)
+    (local $a i32) (local $b i32) (local $#typeswitch_tmp i32)
+    local.get $y
+    local.set $#typeswitch_tmp
     block  ;; label = @1
-      local.get 4
+      local.get $#typeswitch_tmp
       i32.const 0
       i32.eq
       if  ;; label = @2
-        local.get 0
+        local.get $x
         call 2
         br 1 (;@1;)
       end
-      local.get 4
+      local.get $#typeswitch_tmp
       i32.const 1
       i32.eq
       if  ;; label = @2
-        local.get 0
+        local.get $x
         i32.trunc_sat_f64_u
         if  ;; label = @3
           f64.const 0x1.dp+6 (;=116;)
@@ -89,7 +89,7 @@
         end
         br 1 (;@1;)
       end
-      local.get 4
+      local.get $#typeswitch_tmp
       i32.const 3
       i32.eq
       if  ;; label = @2
@@ -113,11 +113,11 @@
         call 0
         br 1 (;@1;)
       end
-      local.get 4
+      local.get $#typeswitch_tmp
       i32.const 4
       i32.eq
       if  ;; label = @2
-        local.get 0
+        local.get $x
         i32.trunc_sat_f64_u
         if  ;; label = @3
           f64.const 0x1.ecp+6 (;=123;)
@@ -136,7 +136,7 @@
         end
         br 1 (;@1;)
       end
-      local.get 4
+      local.get $#typeswitch_tmp
       i32.const 5
       i32.eq
       if  ;; label = @2
@@ -170,9 +170,9 @@
         call 0
         br 1 (;@1;)
       end
-      local.get 0
+      local.get $x
       call 2
     end)
   (memory (;0;) 1)
   (export "$" (memory 0))
-  (export "m" (func 3)))
+  (export "m" (func $main)))
```

</details>