### PR TITLE
feat: add last evaluate result at _ variable in relp 

### DIFF
--- a/runner/repl.js
+++ b/runner/repl.js
@@ -79,6 +79,15 @@ const memoryToString = mem => {
 };
 
 let prev = '';
+
+function setLastEvalExp(prev, ret) {
+  const lastEvalExp = `let _ = ${ret != null ? ret : "undefined"};\n`;
+  if (/let _ = .*;\n/.test(prev)) {
+    return prev.replace(/let _ = .*;\n/, lastEvalExp);
+  }
+  return lastEvalExp + prev;
+}
+
 const run = (source, _context, _filename, callback, run = true) => {
   // hack: print "secret" before latest code ran to only enable printing for new code
 
@@ -110,7 +119,7 @@ const run = (source, _context, _filename, callback, run = true) => {
 
   // callback(null, ret);
 
-  prev = prev + ';\n' + source.trim();
+  prev = setLastEvalExp( prev + ';\n' + source.trim(), ret);  
 
   callback();
 };


### PR DESCRIPTION
I don’t know, but I think this is not a good approach for that. I see that it is not possible to access this property using this._ or globalThis._. I don’t know how to set it global ctx with changes only in the REPL file.
