### PR TITLE
repl: add `--module` flag

### DIFF
--- a/runner/repl.js
+++ b/runner/repl.js
@@ -85,7 +85,7 @@ const run = (source, _context, _filename, callback, run = true) => {
   let toRun = (prev ? (prev + `;\nprint(-0x1337);\n`) : '') + source;
 
   let shouldPrint = !prev;
-  const { exports, pages } = compile(toRun, [], {}, str => {
+  const { exports, pages } = compile(toRun, process.argv.includes('--module') ? [ 'module' ] : [], {}, str => {
     if (shouldPrint) process.stdout.write(str);
     if (str === '-4919') shouldPrint = true;
   });


### PR DESCRIPTION
```
$ ./porf --module
Welcome to Porffor (0.34.5+b927e0e77) running on Node (22.2.0)
using opt -O1, parser acorn, valtype f64

> await 1
1
>
```

To make it easier to play around with TLA in the repl.