### PR TITLE
Add function constructor for literals

### DIFF
--- a/compiler/codegen.js
+++ b/compiler/codegen.js
@@ -1413,6 +1413,7 @@ const getNodeType = (scope, node) => {
 
       if (Object.hasOwn(builtinFuncs, name) && !builtinFuncs[name].typedReturns) return builtinFuncs[name].returnType ?? TYPES.number;
       if (Object.hasOwn(internalConstrs, name)) return internalConstrs[name].type;
+      if (name === 'Function') return TYPES.function;
 
       // check if this is a prototype function
       // if so and there is only one impl (eg charCodeAt)


### PR DESCRIPTION
Title. Parsing the arguments is somewhat hacky, whenever/if we pull in acorn or perhaps only after #34, we should parse these correctly.
This is also vunerable to this type of "attack" (below), but currently I don't really see a better way to do it?
```sh
$ ./porf
> Function('a) { return 1 }; void function (', 'return 2')() // should throw
1
```
But definitely a correctness bug, albeit minor.

(+0.04 Test262 tho :tada:)