### PR TITLE
Fix default destructured args in functions

### DIFF
--- a/compiler/codegen.js
+++ b/compiler/codegen.js
@@ -6084,8 +6084,15 @@ const generateFunc = (scope, decl, outUnused = false) => {
       }
 
       case 'AssignmentPattern': {
-        name = x.left.name;
-        defaultValues[name] = x.right;
+        if (x.left.name) {
+          name = x.left.name;
+          defaultValues[name] = x.right;
+        } else {
+          name = '#arg_dstr' + i;
+          destructuredArgs[name] = x.left;
+          defaultValues[name] = x.right;
+        }
+
         break;
       }
 


### PR DESCRIPTION
Title. Small fix for `([a]=[1]) => ...` patterns.

(+0.71 test262 :tada:)