### PR TITLE
test262/setup: add windows setup script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -366,7 +366,7 @@ builtins/tostring_number: impl radix
 
 ## Test262
 
-For the first time, ensure you run `./test262/setup.sh`.
+For the first time, ensure you run `./test262/setup.sh` (Unix) or `.\test262\setup.cmd` (Windows).
 
 Run `node test262` to run all the tests and get an output of total overall test results.
 

--- a/test262/setup.cmd
+++ b/test262/setup.cmd
@@ -1,0 +1,9 @@
+@echo off
+
+set scriptDir=%~dp0
+pushd %scriptDir%
+
+git clone --depth=1 https://github.com/tc39/test262.git test262
+npm install
+
+popd


### PR DESCRIPTION
Adds a small test262 setup script for windows, mirroring the existing `./test262/setup.sh`.