### PR TITLE
Support string keys in `Porffor.dlopen`

### DIFF
--- a/compiler/codegen.js
+++ b/compiler/codegen.js
@@ -2948,10 +2948,10 @@ const generateVarDstr = (scope, kind, pattern, init, defaultValue, global) => {
       let skipUnusedNames = !!pattern.properties;
       let usedNames = [];
       if (skipUnusedNames) {
-      for (const x of pattern.properties) {
-        const name = x.key.name;
-        usedNames.push(name);
-      }
+        for (const x of pattern.properties) {
+          const name = x.key.name;
+          usedNames.push(name);
+        }
       }
 
       let path = init.arguments[0].value;

--- a/compiler/codegen.js
+++ b/compiler/codegen.js
@@ -2945,22 +2945,25 @@ const generateVarDstr = (scope, kind, pattern, init, defaultValue, global) => {
     Prefs.pgo = false;
 
     try {
+      let skipUnusedNames = !!pattern.properties;
       let usedNames = [];
+      if (skipUnusedNames) {
       for (const x of pattern.properties) {
         const name = x.key.name;
         usedNames.push(name);
+      }
       }
 
       let path = init.arguments[0].value;
       let symbols = {};
 
       for (const x of init.arguments[1].properties) {
-        const name = x.key.name;
-        if (!usedNames.includes(name)) continue;
+        const name = x.key.name || x.key.value;
+        if (skipUnusedNames && !usedNames.includes(name)) continue;
 
         let parameters, result;
         for (const y of x.value.properties) {
-          switch (y.key.name) {
+          switch (y.key.name || y.key.value) {
             case 'parameters':
               parameters = y.value.elements.map(z => z.value);
               break;

--- a/compiler/codegen.js
+++ b/compiler/codegen.js
@@ -2945,13 +2945,10 @@ const generateVarDstr = (scope, kind, pattern, init, defaultValue, global) => {
     Prefs.pgo = false;
 
     try {
-      let skipUnusedNames = !!pattern.properties;
       let usedNames = [];
-      if (skipUnusedNames) {
-        for (const x of pattern.properties) {
-          const name = x.key.name;
-          usedNames.push(name);
-        }
+      for (const x of pattern.properties) {
+        const name = x.key.name;
+        usedNames.push(name);
       }
 
       let path = init.arguments[0].value;
@@ -2959,7 +2956,7 @@ const generateVarDstr = (scope, kind, pattern, init, defaultValue, global) => {
 
       for (const x of init.arguments[1].properties) {
         const name = x.key.name || x.key.value;
-        if (skipUnusedNames && !usedNames.includes(name)) continue;
+        if (!usedNames.includes(name)) continue;
 
         let parameters, result;
         for (const y of x.value.properties) {


### PR DESCRIPTION
Support

```js
const { SDL_Init } = Porffor.dlopen("libSDL2.so", {
  "SDL_Init": {
    "parameters": ["u32"],
    "result": "i32",
  },
});
```