### PR TITLE
builtins/regexp: implement `RegExp.flags` correctly (sort flags)

### DIFF
--- a/compiler/builtins/regexp.ts
+++ b/compiler/builtins/regexp.ts
@@ -87,8 +87,41 @@ export const __RegExp_prototype_source$get = (_this: RegExp) => {
   return Porffor.wasm.i32.load(_this, 0, 0) as bytestring;
 };
 
+// 22.2.6.4 get RegExp.prototype.flags
+// https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp.prototype.flags
 export const __RegExp_prototype_flags$get = (_this: RegExp) => {
-  return Porffor.wasm.i32.load(_this, 0, 4) as bytestring;
+  // 1. Let R be the this value.
+  // 2. If R is not an Object, throw a TypeError exception.
+  if (!Porffor.object.isObject(_this)) throw new TypeError('This is a non-object');
+  let flags: i32 = Porffor.wasm.i32.load(_this, 0, 8);
+  // 3. Let codeUnits be a new empty List.
+  let result: bytestring = Porffor.allocateBytes(4 + 8);
+  // 4. Let hasIndices be ToBoolean(? Get(R, "hasIndices")).
+  // 5. If hasIndices is true, append the code unit 0x0064 (LATIN SMALL LETTER D) to codeUnits.
+  if (flags & 0b01000000) Porffor.bytestring.appendChar(result, 0x64);
+  // 6. Let global be ToBoolean(? Get(R, "global")).
+  // 7. If global is true, append the code unit 0x0067 (LATIN SMALL LETTER G) to codeUnits.
+  if (flags & 0b00000001) Porffor.bytestring.appendChar(result, 0x67);
+  // 8. Let ignoreCase be ToBoolean(? Get(R, "ignoreCase")).
+  // 9. If ignoreCase is true, append the code unit 0x0069 (LATIN SMALL LETTER I) to codeUnits.
+  if (flags & 0b00000010) Porffor.bytestring.appendChar(result, 0x69);
+  // 10. Let multiline be ToBoolean(? Get(R, "multiline")).
+  // 11. If multiline is true, append the code unit 0x006D (LATIN SMALL LETTER M) to codeUnits.
+  if (flags & 0b00000100) Porffor.bytestring.appendChar(result, 0x6d);
+  // 12. Let dotAll be ToBoolean(? Get(R, "dotAll")).
+  // 13. If dotAll is true, append the code unit 0x0073 (LATIN SMALL LETTER S) to codeUnits.
+  if (flags & 0b00001000) Porffor.bytestring.appendChar(result, 0x73);
+  // 14. Let unicode be ToBoolean(? Get(R, "unicode")).
+  // 15. If unicode is true, append the code unit 0x0075 (LATIN SMALL LETTER U) to codeUnits.
+  if (flags & 0b00010000) Porffor.bytestring.appendChar(result, 0x75);
+  // 16. Let unicodeSets be ToBoolean(? Get(R, "unicodeSets")).
+  // 17. If unicodeSets is true, append the code unit 0x0076 (LATIN SMALL LETTER V) to codeUnits.
+  if (flags & 0b10000000) Porffor.bytestring.appendChar(result, 0x76);
+  // 18. Let sticky be ToBoolean(? Get(R, "sticky")).
+  // 19. If sticky is true, append the code unit 0x0079 (LATIN SMALL LETTER Y) to codeUnits.
+  if (flags & 0b00100000) Porffor.bytestring.appendChar(result, 0x79);
+  // 20. Return the String value whose code units are the elements of the List codeUnits. If codeUnits has no elements, the empty String is returned.
+  return result;
 };
 
 export const __RegExp_prototype_global$get = (_this: RegExp) => {

--- a/compiler/builtins_precompiled.js
+++ b/compiler/builtins_precompiled.js
@@ -2847,9 +2847,10 @@ params:[124,127],typedParams:1,returns:[124,127],
 locals:[],localNames:["_this","_this#type"],
 }
 this.__RegExp_prototype_flags$get = {
-wasm:()=>[[32,0],[252,2],[40,0,4],[183],[65,195,1],[15]],
+wasm:(_,{builtin,internalThrow})=>[[32,0],[252,2],[65,9],[16,builtin('__Porffor_object_isObject')],[183],[68,0],[97],[4,64],...internalThrow(_,'TypeError',`This is a non-object`),[26],[11],[32,0],[252,2],[40,0,8],[183],[33,2],[68,4],[68,8],[160],[252,2],[16,builtin('__Porffor_allocateBytes')],[183],[33,3],[32,2],[252,2],[65,192,0],[113],[4,64],[32,3],[65,195,1],[68,100],[65,1],[16,builtin('__Porffor_bytestring_appendChar')],[26],[11],[32,2],[252,2],[65,1],[113],[4,64],[32,3],[65,195,1],[68,103],[65,1],[16,builtin('__Porffor_bytestring_appendChar')],[26],[11],[32,2],[252,2],[65,2],[113],[4,64],[32,3],[65,195,1],[68,105],[65,1],[16,builtin('__Porffor_bytestring_appendChar')],[26],[11],[32,2],[252,2],[65,4],[113],[4,64],[32,3],[65,195,1],[68,109],[65,1],[16,builtin('__Porffor_bytestring_appendChar')],[26],[11],[32,2],[252,2],[65,8],[113],[4,64],[32,3],[65,195,1],[68,115],[65,1],[16,builtin('__Porffor_bytestring_appendChar')],[26],[11],[32,2],[252,2],[65,16],[113],[4,64],[32,3],[65,195,1],[68,117],[65,1],[16,builtin('__Porffor_bytestring_appendChar')],[26],[11],[32,2],[252,2],[65,128,1],[113],[4,64],[32,3],[65,195,1],[68,118],[65,1],[16,builtin('__Porffor_bytestring_appendChar')],[26],[11],[32,2],[252,2],[65,32],[113],[4,64],[32,3],[65,195,1],[68,121],[65,1],[16,builtin('__Porffor_bytestring_appendChar')],[26],[11],[32,3],[65,195,1],[15]],
 params:[124,127],typedParams:1,returns:[124,127],
-locals:[],localNames:["_this","_this#type"],
+locals:[124,124],localNames:["_this","_this#type","flags","result"],
+usesTag:1,
 }
 this.__RegExp_prototype_global$get = {
 wasm:()=>[[32,0],[252,2],[40,0,8],[65,1],[113],[183],[65,2],[15]],


### PR DESCRIPTION
I tried to calculate the size of the resulting string with [popcnt](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Numeric/Population_count) instead of always using the maximum possible (8), not sure it's really necessary but I tried various variations of this and I would like to understand what I'm doing wrong:
```js
  let result: bytestring = Porffor.allocateBytes(Porffor.wasm`
    i32.const ${flags & 0xffff}
    i32.popcnt
    i32.const 4
    i32.add
  `);
```