### PR TITLE
fix: update `node-repl-polyfill` to install from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {},
   "dependencies": {
     "acorn": "^8.15.0",
-    "node-repl-polyfill": "github:CanadaHonk/node-repl-polyfill"
+    "node-repl-polyfill": "^0.1.2"
   },
   "optionalDependencies": {
     "@babel/parser": "^7.24.4",


### PR DESCRIPTION
It looks like `node-repl-polyfill` is already published to npm so we should use it as a dependency so that it is versioned appropriately.