### PR TITLE
fix: Deno successfully loads parser module with npm machinery

### DIFF
--- a/compiler/parse.js
+++ b/compiler/parse.js
@@ -17,7 +17,7 @@ globalThis.parser = '';
 let parse;
 const loadParser = async (fallbackParser = 'acorn', forceParser) => {
   parser = forceParser ?? Prefs.parser ?? fallbackParser;
-  const mod = (await import((globalThis.document || globalThis.Deno ? 'https://esm.sh/' : '') + parser));
+  const mod = (await import((globalThis.document ? 'https://esm.sh/' : '') + parser));
   if (mod.parseSync) parse = mod.parseSync;
     else parse = mod.parse;
 };


### PR DESCRIPTION
Avoids error when run as `deno run -A npm:porffor file.js`:

    Uncaught (in promise) TypeError: [ERR_UNSUPPORTED_ESM_URL_SCHEME] Only file and data URLs are supported by the default ESM loader. Received protocol 'https'