### PR TITLE
compiler: hoist late `var` declarations

### DIFF
--- a/compiler/codegen.js
+++ b/compiler/codegen.js
@@ -7145,53 +7145,14 @@ const generateFunc = (scope, decl, forceNoExpr = false) => {
   return [ func, out ];
 };
 
-// Do an initial pass to find all bare `var` declarations (e.g. `var foo;`) and hoist them
-// This ensures that, in strict mode, late `var`s are not considered a reference error
-const hoistVarDeclarations = (body) => {
-  const varDeclarations = [];
-
-  const result = body.map(statement => {
-    if (statement.kind === 'var' && statement.type === 'VariableDeclaration') {
-      return {
-        ...statement,
-        // filter out bare `var` declarations
-        declarations: statement.declarations.filter(declaration => {
-          if (declaration.type === 'VariableDeclarator' && declaration.init === null) {
-            varDeclarations.push(declaration);
-            return false;
-          }
-          return true;
-        })
-      };
-    }
-    return statement;
-  });
-
-  // hoist
-  result.unshift(
-    ...varDeclarations.map(declaration => ({
-      type: 'VariableDeclaration',
-      kind: 'var',
-      // since this is a kind of pseudo-node not in source code, set start/end to 0
-      start: 0,
-      end: 0,
-      declarations: [declaration]
-    }))
-  );
-
-  return result;
-};
-
 const generateBlock = (scope, decl) => {
   let out = [];
 
   inferBranchStart(scope);
 
-  const body = hoistVarDeclarations(decl.body);
-
-  let len = body.length, j = 0;
+  let len = decl.body.length, j = 0;
   for (let i = 0; i < len; i++) {
-    const x = body[i];
+    const x = decl.body[i];
     if (isEmptyNode(x)) continue;
 
     if (j++ > 0) out.push([ Opcodes.drop ]);


### PR DESCRIPTION
Fixes #285 

This is a bit of a hacky solution, so I'm open to other suggestions. We essentially rewrite the AST to hoist bare `var` declarations (e.g. `var foo;`) to the top of their scope. This improves the test262 score by 1 test:

Before:

```
test262: 59.92% (-2.01) | 🧪 52633 (+1915) | 🤠 31537 (+127) | ❌ 7142 (-404) | 💀 13640 (+2160) | 🏗️  1 (+1) | 💥 270 (+31) | ⏰ 43
```

After:

```
test262: 59.92% (-2.01) | 🧪 52633 (+1915) | 🤠 31538 (+128) | ❌ 7141 (-405) | 💀 13640 (+2160) | 🏗️  1 (+1) | 💥 270 (+31) | ⏰ 43
```

The part I'm most unsure about is setting the `start`/`end` to 0/0 but I made a note in the code. Semantically the AST should be the same before and after since it doesn't matter if you put a `var foo;` at the top or end of a scope.