### PR TITLE
builtins: fix Error prototype property descriptors

### DIFF
--- a/compiler/builtins.js
+++ b/compiler/builtins.js
@@ -353,6 +353,17 @@ export const BuiltinVars = ({ builtinFuncs }) => {
       props.name = { value: '', configurable: true };
     }
 
+    // special case: Error.prototype.name = 'Error' (and other error types)
+    // Per spec, Error.prototype.name should be a data property, not a getter
+    const errorTypes = ['Error', 'AggregateError', 'TypeError', 'ReferenceError', 'SyntaxError', 'RangeError', 'EvalError', 'URIError', 'Test262Error'];
+    for (const errorType of errorTypes) {
+      if (x === `__${errorType}_prototype`) {
+        props.name = { value: errorType, writable: true, configurable: true };
+        props.message = { value: '', writable: true, configurable: true };
+        break;
+      }
+    }
+
     // add constructor for constructors
     const name = x.slice(2, x.indexOf('_', 2));
     if (builtinFuncs[name]?.constr) {


### PR DESCRIPTION
Add Error.prototype.name and message as data properties per spec

new passes
built-ins/Error/name.js
built-ins/Error/the-initial-value-of-errorprototypemessage-is-the-empty-string.js
built-ins/AggregateError/prototype/message.js
built-ins/AggregateError/prototype/name.js
built-ins/Error/prototype/message/prop-desc.js
built-ins/Error/prototype/name/prop-desc.js
built-ins/NativeErrors/RangeError/prototype/message.js
built-ins/NativeErrors/RangeError/prototype/name.js
built-ins/NativeErrors/EvalError/prototype/message.js
built-ins/NativeErrors/EvalError/prototype/name.js
built-ins/NativeErrors/TypeError/prototype/message.js
built-ins/NativeErrors/TypeError/prototype/name.js
built-ins/NativeErrors/URIError/prototype/name.js
built-ins/NativeErrors/URIError/prototype/message.js
built-ins/NativeErrors/ReferenceError/prototype/name.js
built-ins/NativeErrors/SyntaxError/prototype/name.js
built-ins/NativeErrors/SyntaxError/prototype/message.js
built-ins/NativeErrors/ReferenceError/prototype/message.js
language/statements/class/subclass/builtin-objects/NativeError/EvalError-name.js
language/statements/class/subclass/builtin-objects/NativeError/RangeError-name.js
language/statements/class/subclass/builtin-objects/NativeError/ReferenceError-name.js
language/statements/class/subclass/builtin-objects/NativeError/URIError-name.js
language/statements/class/subclass/builtin-objects/NativeError/SyntaxError-name.js
language/statements/class/subclass/builtin-objects/NativeError/TypeError-name.js