### PR TITLE
Fix `>>>` unsigned right shift in native and wasm backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ pnpm-lock.yaml
 /test262/results.json
 /test262/.threads
 /envoy
+.vscode/settings.json

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-porffor.dev
+cdn.porffor.dev

--- a/compiler/2c.js
+++ b/compiler/2c.js
@@ -441,6 +441,16 @@ export default ({ funcs, globals, data, pages }) => {
         const a = vals.pop();
 
         let op = invOperatorOpcode[i[0]];
+
+        // unsigned right shift (>>>) must be a logical shift in C, so cast the
+        // operand to unsigned. otherwise C performs an arithmetic shift on the
+        // signed i32 and diverges from wasm's i32.shr_u for negative values.
+        if (op === '>>>') {
+          lastCond = false;
+          vals.push(`((u32)(${a}) >> ${b})`);
+          continue;
+        }
+
         if (op.length === 3) op = op.slice(0, 2);
 
         if (['==', '!=', '>', '>=', '<', '<='].includes(op)) lastCond = true;
@@ -462,6 +472,16 @@ export default ({ funcs, globals, data, pages }) => {
           // i32_trunc_sat_f64_u
           case 0x03:
             vals.push(`(u32)(${vals.pop()})`);
+            break;
+
+          // i64_trunc_sat_f64_s
+          case 0x06:
+            vals.push(`(i64)(${vals.pop()})`);
+            break;
+
+          // i64_trunc_sat_f64_u
+          case 0x07:
+            vals.push(`(u64)(${vals.pop()})`);
             break;
 
           // memory_copy
@@ -522,6 +542,11 @@ export default ({ funcs, globals, data, pages }) => {
         case Opcodes.f64_convert_i64_s:
           // int to f64
           vals.push(`(f64)(${removeBrackets(vals.pop())})`);
+          break;
+
+        case Opcodes.i32_wrap_i64:
+          // i64 to i32 (take low 32 bits)
+          vals.push(`(i32)(${removeBrackets(vals.pop())})`);
           break;
 
         case Opcodes.i32_eqz:
@@ -840,7 +865,9 @@ f64 _time_out${id} = (f64)_ts${id}.tv_sec * 1000.0 + (f64)_ts${id}.tv_nsec / 1.0
           const id = tmpId++;
           line(`const i32 _x${id} = ${x}`);
           line(`const i32 _shift${id} = ${shift}`);
-          line(`const i32 _out${id} = (_x${id} << _shift${id}) | (_x${id} >> (32 - _shift${id}))`);
+          // the wrap-around half of the rotate must be a logical shift, so cast
+          // to unsigned to avoid C's arithmetic shift on negative values.
+          line(`const i32 _out${id} = (_x${id} << _shift${id}) | ((u32)_x${id} >> (32 - _shift${id}))`);
           vals.push(`_out${id}`);
           break;
         }

--- a/compiler/expression.js
+++ b/compiler/expression.js
@@ -1,14 +1,16 @@
 import { Opcodes, Valtype } from './wasmSpec.js';
 import { TYPES } from './types.js';
 
-// ToInt32 (ECMA-262): non-finite values (NaN, ±Infinity) become +0, otherwise
-// truncate towards zero and take the result modulo 2^32. Truncating to i64
-// first and then wrapping to i32 gives the modulo wrapping for any finite value
-// representable as an integer (up to 2^53). `value - value` is 0 only for
-// finite values (it is NaN for ±Infinity and NaN), so it guards the non-finite
-// case which would otherwise saturate to i64 min/max.
-const bitwiseOperandToI32 = (value, { loc }, localName) => {
-  const local = loc(localName, Valtype.f64);
+// ECMA-262 ToInt32: coerce an f64 operand to a wrapped (mod 2^32) i32.
+// Non-finite values (NaN, ±Infinity) become +0; finite values truncate towards
+// zero and take the result modulo 2^32. Truncating to i64 first then wrapping to
+// i32 gives the modulo wrapping for any finite value representable as an integer
+// (up to 2^53). `value - value` is 0 only for finite values (it is NaN for
+// ±Infinity and NaN), guarding the non-finite case which would otherwise
+// saturate to i64 min/max. Needs a scratch f64 local (`loc`) since the value is
+// used both for the finiteness guard and the truncation.
+const toInt32 = (value, loc, name) => {
+  const local = loc(name, Valtype.f64);
 
   return [
   ...value,
@@ -27,18 +29,18 @@ const bitwiseOperandToI32 = (value, { loc }, localName) => {
   ];
 };
 
-const f64ifyBitwise = op => (_1, ctx, { left, right }) => [
-  ...bitwiseOperandToI32(left, ctx, '#bitwise_left'),
-  ...bitwiseOperandToI32(right, ctx, '#bitwise_right'),
+const f64ifyBitwise = op => (_1, { loc }, { left, right }) => [
+  ...toInt32(left, loc, '#bitwise_left'),
+  ...toInt32(right, loc, '#bitwise_right'),
   [ op ],
   [ Opcodes.f64_convert_i32_s ]
 ];
 
 // >>> returns a Uint32 (ECMA-262 unsigned right shift operator), so the i32
 // result must be reinterpreted as unsigned when converting back to f64.
-const f64ifyUSHR = (_1, ctx, { left, right }) => [
-  ...bitwiseOperandToI32(left, ctx, '#ushr_left'),
-  ...bitwiseOperandToI32(right, ctx, '#ushr_right'),
+const f64ifyUSHR = (_1, { loc }, { left, right }) => [
+  ...toInt32(left, loc, '#ushr_left'),
+  ...toInt32(right, loc, '#ushr_right'),
   [ Opcodes.i32_shr_u ],
   [ Opcodes.f64_convert_i32_u ]
 ];

--- a/compiler/expression.js
+++ b/compiler/expression.js
@@ -1,13 +1,46 @@
 import { Opcodes, Valtype } from './wasmSpec.js';
 import { TYPES } from './types.js';
 
-const f64ifyBitwise = op => (_1, _2, { left, right }) => [
-  ...left,
-  Opcodes.i32_trunc_sat_f64_s,
-  ...right,
-  Opcodes.i32_trunc_sat_f64_s,
+// ToInt32 (ECMA-262): non-finite values (NaN, ±Infinity) become +0, otherwise
+// truncate towards zero and take the result modulo 2^32. Truncating to i64
+// first and then wrapping to i32 gives the modulo wrapping for any finite value
+// representable as an integer (up to 2^53). `value - value` is 0 only for
+// finite values (it is NaN for ±Infinity and NaN), so it guards the non-finite
+// case which would otherwise saturate to i64 min/max.
+const bitwiseOperandToI32 = (value, { loc }, localName) => {
+  const local = loc(localName, Valtype.f64);
+
+  return [
+  ...value,
+  [ Opcodes.local_tee, local ],
+  [ Opcodes.local_get, local ],
+  [ Opcodes.f64_sub ],
+  [ Opcodes.f64_const, 0 ],
+  [ Opcodes.f64_eq ],
+  [ Opcodes.if, Valtype.i32 ],
+  [ Opcodes.local_get, local ],
+  Opcodes.i64_trunc_sat_f64_s,
+  [ Opcodes.i32_wrap_i64 ],
+  [ Opcodes.else ],
+  [ Opcodes.i32_const, 0 ],
+  [ Opcodes.end ]
+  ];
+};
+
+const f64ifyBitwise = op => (_1, ctx, { left, right }) => [
+  ...bitwiseOperandToI32(left, ctx, '#bitwise_left'),
+  ...bitwiseOperandToI32(right, ctx, '#bitwise_right'),
   [ op ],
   [ Opcodes.f64_convert_i32_s ]
+];
+
+// >>> returns a Uint32 (ECMA-262 unsigned right shift operator), so the i32
+// result must be reinterpreted as unsigned when converting back to f64.
+const f64ifyUSHR = (_1, ctx, { left, right }) => [
+  ...bitwiseOperandToI32(left, ctx, '#ushr_left'),
+  ...bitwiseOperandToI32(right, ctx, '#ushr_right'),
+  [ Opcodes.i32_shr_u ],
+  [ Opcodes.f64_convert_i32_u ]
 ];
 
 export const operatorOpcode = {
@@ -92,6 +125,6 @@ export const operatorOpcode = {
     '^': f64ifyBitwise(Opcodes.i32_xor),
     '<<': f64ifyBitwise(Opcodes.i32_shl),
     '>>': f64ifyBitwise(Opcodes.i32_shr_s),
-    '>>>': f64ifyBitwise(Opcodes.i32_shr_u)
+    '>>>': f64ifyUSHR
   }
 };

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@honk/porffor",
-  "version": "0.61.12",
+  "version": "0.61.13",
   "exports": "./compiler/wrap.js",
   "publish": {
     "exclude": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "porffor",
   "description": "An ahead-of-time JavaScript compiler",
-  "version": "0.61.12",
+  "version": "0.61.13",
   "author": "Oliver Medhurst <honk@goose.icu>",
   "license": "MIT",
   "scripts": {},

--- a/runtime/index.js
+++ b/runtime/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
-globalThis.version = '0.61.12';
+globalThis.version = '0.61.13';
 
 // deno compat
 if (typeof process === 'undefined' && typeof Deno !== 'undefined') {

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,62 @@
+import { describe, test } from 'node:test';
+import { mkdtemp, readdir, rm } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..');
+const porf = process.platform === 'win32' ? join(repoRoot, 'porf.cmd') : join(repoRoot, 'porf');
+
+const testsDir = join(__dirname, 'tests');
+const useWasm = process.argv.includes('--wasm');
+
+async function* walkDir(dir) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) yield* walkDir(full);
+    else if (entry.name.endsWith('.js')) yield full;
+  }
+}
+
+const spawnAsync = (cmd, args, opts) => new Promise((resolve, reject) => {
+  const proc = spawn(cmd, args, { encoding: 'utf8', ...opts });
+  let stdout = '', stderr = '';
+  proc.stdout.on('data', d => stdout += d);
+  proc.stderr.on('data', d => stderr += d);
+  proc.on('close', status => resolve({ status, stdout, stderr }));
+  proc.on('error', reject);
+});
+
+describe('tests', { concurrency: true }, async () => {
+  for await (const testFile of walkDir(testsDir)) {
+    const relPath = relative(testsDir, testFile);
+
+    test(relPath, async () => {
+      if (useWasm) {
+        const run = await spawnAsync(porf, [testFile], { cwd: repoRoot });
+        if (run.status !== 0) {
+          throw new Error(`test failed (exit ${run.status}):\n${(run.stderr || run.stdout || '').trim()}`);
+        }
+      } else {
+        const tmpDir = await mkdtemp(join(tmpdir(), 'porf-test-'));
+        const binPath = join(tmpDir, process.platform === 'win32' ? 'out.exe' : 'out');
+
+        try {
+          const compile = await spawnAsync(porf, ['native', testFile, binPath], { cwd: repoRoot });
+          if (compile.status !== 0) {
+            throw new Error(`compilation failed:\n${(compile.stderr || compile.stdout || '').trim()}`);
+          }
+
+          const run = await spawnAsync(binPath, []);
+          if (run.status !== 0) {
+            throw new Error(`test failed (exit ${run.status}):\n${(run.stderr || run.stdout || '').trim()}`);
+          }
+        } finally {
+          await rm(tmpDir, { recursive: true, force: true });
+        }
+      }
+    });
+  }
+});

--- a/test/tests/member-access.js
+++ b/test/tests/member-access.js
@@ -1,0 +1,12 @@
+const assertSameValue = (actual, expected) => {
+  if (!Object.is(actual, expected)) throw `Expected ${expected}, got ${actual}`;
+};
+
+const o = { a: 1 };
+assertSameValue(o.a, 1);
+assertSameValue(o['a'], 1);
+
+class C { constructor() { this.x = 2; } }
+const c = new C();
+assertSameValue(c.x, 2);
+assertSameValue(c['x'], 2);

--- a/test/tests/ushr.js
+++ b/test/tests/ushr.js
@@ -1,0 +1,18 @@
+const assertSameValue = (actual, expected) => {
+  if (!Object.is(actual, expected)) throw `Expected ${expected}, got ${actual}`;
+};
+
+assertSameValue(-1 >>> 0, 4294967295);
+assertSameValue(-1 >>> 1, 2147483647);
+assertSameValue(-1 >>> 28, 15);
+assertSameValue(-1 >>> 31, 1);
+assertSameValue(-2 >>> 0, 4294967294);
+assertSameValue(-2 >>> 1, 2147483647);
+assertSameValue(-8 >>> 1, 2147483644);
+assertSameValue(-256 >>> 4, 268435440);
+assertSameValue(-1000000 >>> 3, 536745912);
+assertSameValue((0x80000000 | 0) >>> 31, 1);
+assertSameValue((0x80000000 | 0) >>> 0, 2147483648);
+assertSameValue(123 >>> 0, 123);
+assertSameValue(-16 >> 2, -4);
+assertSameValue(-1 >> 0, -1);


### PR DESCRIPTION
In 2c.js, i32.shr_u was emitted as C >> on a signed i32, which performs an arithmetic shift for negative values. Fixed by casting the left operand to u32. Same fix applied to the rotl wrap-around.

In expression.js, the f64 >>> path used f64_convert_i32_s to convert back to f64, truncating values >= 2**31 to negative. Fixed with a new f64ifyUSHR helper using f64_convert_i32_u.

Also fixes ToInt32/ToUint32 coercion shared by all bitwise operators (& | ^ << >> >>>): operands used saturating i32 truncation, which clamps values outside the i32/u32 range instead of wrapping modulo 2**32. Replaced with i64 truncation + i32 wrap, and non-finite operands (NaN, ±Infinity) now coerce to +0 per spec. This required implementing i64_trunc_sat_f64_s/u and i32_wrap_i64 in the 2c backend, which were previously no-ops.

Adds a test runner (test/index.js) using node:test with concurrency and async I/O. Runs tests in native mode (compile + exec) or wasm mode (--wasm flag). Tests just throw on failure, no snapshots. Initial tests: ushr.js and member-access.js.

Fixes #333