### PR TITLE
fix: `delete` on bare (implicit) global variables (#155)

### DIFF
--- a/compiler/codegen.js
+++ b/compiler/codegen.js
@@ -818,6 +818,7 @@ const generateIdent = (scope, decl) => {
   if (decl._builtinMember && decl.name in builtinFuncs) return materializeFunctionValue(scope, includeBuiltin(scope, decl.name));
 
   if (decl.name in scope.locals) (scope.locals[decl.name].metadata ??= {}).read = true;
+  if (!decl._skipImplicitGuard) guardImplicitGlobalRead(scope, decl.name);
   return lookup(scope, decl.name, !(decl.name === 'arguments' && decl._resolvedBinding))
     ?? internalThrow(scope, 'ReferenceError', `${unhackName(decl.name)} is not defined`);
 };
@@ -2222,6 +2223,26 @@ const addVarMetadata = (scope, name, global = false, metadata = {}) => {
   }
 };
 
+// sloppy `a = 1` with no declaration is a configurable global: `delete a` removes it
+// and later reads throw. A companion i32 global (0 = defined, 1 = deleted) tracks this.
+const implicitGlobalDeletedFlag = name => '#implicitdel#' + name;
+const isImplicitGlobal = name => globals[name]?.metadata?.implicit === true;
+
+const markImplicitGlobal = (scope, name) => {
+  globals[name].metadata ??= {};
+  globals[name].metadata.implicit = true;
+  allocVar(scope, implicitGlobalDeletedFlag(name), true, T.i32);
+};
+
+const setImplicitGlobalDeleted = (scope, name, deleted) =>
+  stmt(scope, Assign(Global(implicitGlobalDeletedFlag(name), T.i32), Const(T.i32, deleted ? 1 : 0)));
+
+const guardImplicitGlobalRead = (scope, name) => {
+  if (name in scope.locals || !isImplicitGlobal(name)) return;
+  emitIf(scope, Bin('!=', T.i32, Global(implicitGlobalDeletedFlag(name), T.i32), Const(T.i32, 0)),
+    () => internalThrow(scope, 'ReferenceError', `${unhackName(name)} is not defined`));
+};
+
 const HOIST_DECL = 1;
 const markVarHoists = (scope, body) => {
   scope.hoists ??= new Map();
@@ -2378,6 +2399,8 @@ const setLocalWithType = (scope, name, isGlobal, decl, tee = false, overrideType
     : ref[N_TYPE] === T.f64 ? numValue(value)
     : ref[N_TYPE] === T.ptr ? JvPtr(value)
     : coerceValue(value, ref[N_TYPE]));
+  // a write redefines the binding, clearing any prior delete
+  if (isGlobal && isImplicitGlobal(name)) setImplicitGlobalDeleted(scope, name, false);
   return tee ? (ref[N_TYPE] === T.f64 ? valNumber(ref) : ref) : undefined;
 };
 
@@ -3093,6 +3116,7 @@ const generateAssign = (scope, decl, valueUnused = false) => {
 
     // set global and return (eg a = 2)
     generateVarDstr(scope, 'var', name, decl.right, undefined, true);
+    markImplicitGlobal(scope, name);
     return valueUnused ? valUndefined() : generate(scope, decl.left);
   }
 
@@ -3171,7 +3195,13 @@ const generateUnary = (scope, decl) => {
 
       let toReturn = true, toGenerate = true;
       if (decl.argument.type === 'Identifier') {
+        const name = decl.argument.name;
         if (ifIdentifierErrors(scope, decl.argument)) { toReturn = true; toGenerate = false; }
+        else if (!(name in scope.locals) && isImplicitGlobal(name)) {
+          // configurable implicit global: mark deleted so later reads throw
+          setImplicitGlobalDeleted(scope, name, true);
+          toReturn = true; toGenerate = false;
+        }
         else toReturn = false;
       }
       if (toGenerate) exprStmt(scope, generate(scope, decl.argument));
@@ -3181,8 +3211,13 @@ const generateUnary = (scope, decl) => {
     case 'typeof': {
       if (ifIdentifierErrors(scope, decl.argument)) return makeString(scope, 'undefined');
 
+      // typeof a deleted implicit global reads 'undefined' without throwing: skip the guard, branch on the flag
+      const typeofName = decl.argument.type === 'Identifier' ? decl.argument.name : null;
+      const implicitTypeof = typeofName != null && !(typeofName in scope.locals) && isImplicitGlobal(typeofName);
+      if (implicitTypeof) decl.argument._skipImplicitGuard = true;
+
       const arg = reuse(scope, generate(scope, decl.argument));
-      return typeSwitch(scope, arg, knownType(scope, getNodeType(scope, decl.argument)), [
+      const result = typeSwitch(scope, arg, knownType(scope, getNodeType(scope, decl.argument)), [
         [ TYPES.number, () => makeString(scope, 'number') ],
         [ TYPES.boolean, () => makeString(scope, 'boolean') ],
         [ [ TYPES.string, TYPES.bytestring ], () => makeString(scope, 'string') ],
@@ -3193,6 +3228,14 @@ const generateUnary = (scope, decl) => {
 
         [ 'default', () => makeString(scope, 'object') ]
       ]);
+
+      if (implicitTypeof) {
+        const res = tmp(scope, T.jsval, result);
+        emitIf(scope, Bin('!=', T.i32, Global(implicitGlobalDeletedFlag(typeofName), T.i32), Const(T.i32, 0)),
+          () => stmt(scope, Assign(res, makeString(scope, 'undefined'))));
+        return res;
+      }
+      return result;
     }
   }
 };

--- a/compiler/codegen.js
+++ b/compiler/codegen.js
@@ -1208,7 +1208,16 @@ const irBuiltinHelpers = (scope, name, def) => ({
       for (const name in globals) {
         if (name[0] === '#' || seen.has(name) || globals[name].metadata?.kind !== 'var') continue;
         const type = globals[name].type ?? T.jsval;
-        push(name, type === T.jsval ? Global(name, T.jsval) : valNumber(Global(name, type)));
+        const value = type === T.jsval ? Global(name, T.jsval) : valNumber(Global(name, type));
+        if (globals[name].metadata?.implicit) {
+          // a deleted implicit global is no longer an own property of the global object
+          seen.add(name);
+          sync.push(If(Bin('==', T.i32, Global(implicitGlobalDeletedFlag(name), T.i32), Const(T.i32, 0)),
+            [ builtinCall(scope, '__Porffor_object_set', [ objJv, makeString(scope, name), value ]) ],
+            [ builtinCall(scope, '__Porffor_object_delete', [ objJv, makeString(scope, name) ]) ]));
+        } else {
+          push(name, value);
+        }
       }
     };
 
@@ -2889,6 +2898,7 @@ const generateAssign = (scope, decl, valueUnused = false) => {
   if (check) {
     if (local !== undefined) {
       // fast path: conditional in-place store, the var itself is the result: if (check(x)) x = y
+      guardImplicitGlobalRead(scope, name);
       const ref = isGlobal ? Global(name, globals[name]?.type ?? T.jsval) : Local(name, scope.locals[name]?.type ?? T.jsval);
       const cond = check(scope, ref, getType(scope, name));
       setInferred(scope, name, knownType(scope, getNodeType(scope, decl)), isGlobal);
@@ -3128,6 +3138,7 @@ const generateAssign = (scope, decl, valueUnused = false) => {
   }
 
   // compound assignment: left @= right -> left = left @ right
+  guardImplicitGlobalRead(scope, name);
   const cur = isGlobal ? Global(name, globals[name]?.type ?? T.jsval) : Local(name, scope.locals[name]?.type ?? T.jsval);
   const newVal = performOp(scope, op, cur, generate(scope, decl.right), getType(scope, name), getNodeType(scope, decl.right));
   setInferred(scope, name, knownType(scope, getNodeType(scope, decl)), isGlobal);
@@ -3252,6 +3263,7 @@ const generateUpdate = (scope, decl, valueUnused = false) => {
   const [ local, isGlobal ] = lookupName(scope, name);
   if (local != null) {
     // fast path: a local/global. todo: not as compliant as the slow path (non-numbers)
+    guardImplicitGlobalRead(scope, name);
     const ref = isGlobal ? Global(name, globals[name]?.type ?? T.jsval) : Local(name, scope.locals[name]?.type ?? T.jsval);
     const inc = v => Bin(decl.operator === '++' ? '+' : '-', T.f64, numValue(v), Const(T.f64, 1));
     const incForRef = v => ref[N_TYPE] === T.jsval ? valNumber(inc(v))


### PR DESCRIPTION
Fixes #155.

In sloppy mode, assigning to an undeclared name (`a = 1`) creates a **configurable**
property on the global object. Per spec `delete a` removes the binding, later reads
throw `ReferenceError`, and the property disappears from `globalThis`. Porffor stored
bare assignments as ordinary `var`-kind globals, so `delete a` was a no-op:

```js
a = 1;
delete a;   // was: false (no-op)   →  now: true
a;          // was: 1               →  now: ReferenceError
```

## Approach

Under AOT the binding can't be unmapped at runtime, so implicit globals are tagged and
tracked with a companion `i32` global (`0` = defined, `1` = deleted; C zero-init = defined):

- `delete a` sets the flag, returns `true`
- writes clear the flag (revive)
- reads throw when flagged — plain reads and the operand reads of compound (`a += 1`),
  update (`a++`), logical (`a ??= x`) assignments
- `typeof a` reads `'undefined'` when deleted
- the `globalThis` sync sets the property when live, deletes it when flagged
- declared `var`/`let`/`const`/params/functions unchanged (delete stays `false` no-op)

## Testing

```js
a = 1; delete a; a;            // ReferenceError
b = 1; delete b; b = 5; b;     // 5 (revived)
var v = 1; delete v;           // false, v === 1
```