### PR TITLE
cli: report parser SyntaxErrors cleanly instead of a raw Node stack

### DIFF
--- a/runtime/index.js
+++ b/runtime/index.js
@@ -171,6 +171,14 @@ entrypoint: {
         runStatus = e.status ?? 1;
       }
     }
+  } catch (e) {
+    // parse/compile errors: report cleanly instead of a raw Node stack (-d keeps the stack)
+    if (e instanceof SyntaxError && !Prefs.d) {
+      process.stderr.write(`\x1B[31m\x1B[1mSyntaxError\x1B[0m: ${e.message}\n`);
+      process.exitCode = 1;
+      break entrypoint;
+    }
+    throw e;
   } finally {
     if (tmpRunDir) fs.rmSync(tmpRunDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Parse/compile errors thrown from the compiler were uncaught at the CLI entrypoint,
so any invalid input printed a full Node.js stack trace and version banner.

Before:

```console
$ porf -e "let x = ;"
file:///.../compiler/parser/index.js:45
  throw new SyntaxError(`${msg} (${lineCol(p)})`);
        ^
SyntaxError: Unexpected token ';' (1:8)
    at raise (.../parser/index.js:45:9)
    at unexpected (.../parser/index.js:952:3)
    ... (10+ frames)
Node.js v24.15.0
```

After:

```console
$ porf -e "let x = ;"
SyntaxError: Unexpected token ';' (1:8)
```