### PR TITLE
allocate closure env before setting named function expression

### DIFF
--- a/compiler/codegen.js
+++ b/compiler/codegen.js
@@ -4613,14 +4613,6 @@ const generateFunc = (scope, decl, forceNoExpr = false) => {
 
       func.identFailEarly = true;
 
-      // a named function expression sees its own name
-      if (decl.type === 'FunctionExpression' && decl.id?.name && (func.selfAware || func.closureOwnLocals?.[func.name])) {
-        allocVar(func, func.name);
-        setVarMetadata(func, func.name, false, { kind: 'function-name' });
-        setLocalWithType(func, func.name, false,
-          func.selfAware ? Local('#callee', T.jsval) : materializeFunctionValue(func, func), false, TYPES.function);
-      }
-
       // closure env: object holding this func's captured locals (+ #this), chained to the inherited env
       if (hasClosureOwnEnv(func)) {
         const closureEnvNames = Object.keys(func.closureOwnLocals ?? {});
@@ -4644,6 +4636,14 @@ const generateFunc = (scope, decl, forceNoExpr = false) => {
             () => exprStmt(func, builtinCall(func, '__Porffor_object_setPrototype', [
               Local('#closure_env_local', T.jsval), valOf(Local('#env', T.ptr), TYPES.object) ])));
         }
+      }
+
+      // a named function expression sees its own name
+      if (decl.type === 'FunctionExpression' && decl.id?.name && (func.selfAware || func.closureOwnLocals?.[func.name])) {
+        allocVar(func, func.name);
+        setVarMetadata(func, func.name, false, { kind: 'function-name' });
+        setLocalWithType(func, func.name, false,
+          func.selfAware ? Local('#callee', T.jsval) : materializeFunctionValue(func, func), false, TYPES.function);
       }
 
       // dynamic calls can deliver any receiver: prototype builtins coerce or type-guard #this by annotated type


### PR DESCRIPTION
fixes #351 

Fixes a compile-time crash (`missing #closure_env_local in <fn>`) when compiling named function expressions that contain closure-captured variables.

The error occurred because setting up the self-referential function binding called `materializeFunctionValue`, which attempted to read `#closure_env_local` before `#closure_env_local` had been allocated. Reordered the closure environment allocation block to run before the named function expression binding setup.