### PR TITLE
codegen: ignore return type annotations on coroutines

### DIFF
--- a/compiler/codegen.js
+++ b/compiler/codegen.js
@@ -4807,7 +4807,10 @@ const generateFunc = (scope, decl, forceNoExpr = false) => {
   funcs.push(func);
   funcsByIndex[func.index] = func;
 
-  if (typedInput && decl.returnType) {
+  // async/generator bodies are coroutines: the annotation (Promise<T>, Generator<T>)
+  // describes what the *call* produces, not what the body returns, so applying it here
+  // would mislabel the resolved value as a promise/generator
+  if (typedInput && decl.returnType && !decl.async && !decl.generator) {
     const { type, types, irType } = extractTypeAnnotation(decl.returnType);
     if (irType != null) func.retType = irType;
     if (type != null) { typeUsed(func, type); func.returnType = type; }


### PR DESCRIPTION
A return type annotation on an `async` function was applied to the coroutine body, so `Promise<number>` set `func.returnType = TYPES.promise` and `coerceReturnValue` re-tagged the resolved number as a promise. Awaiting the call then gave back a bogus promise instead of the value. Skipping the annotation for `async` and generator functions fixes it: it describes what the call produces, not what the body returns, and the call's type already comes from `func.async`/`func.generator` in `getNodeType`.

```ts
async function f(): Promise<number> { return 5; }
console.log(await f()); // was Promise (state: <rejected>, result: 0), now 5
```

Unwrapping `Promise<T>` to `T` for the body would be wrong instead of just skipping, since `return somePromise` is also valid under a `Promise<T>` annotation.

Only affects `-t`, and `builtins_precompiled.js` regenerates identical since no builtin is an annotated coroutine.

test262 results are the same before and after.
